### PR TITLE
More patches for `esy`

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1783,7 +1783,7 @@ if (skia_enable_tools) {
     skia_h = "$target_gen_dir/skia.h"
     script = "gn/find_headers.py"
 
-    args = [ rebase_path("//bin/gn") ] + [ rebase_path("//") ] +
+    args = [ "gn" ] + [ rebase_path("//") ] +
            [ rebase_path(skia_h, root_build_dir) ] +
            rebase_path(skia_public_includes)
     depfile = "$skia_h.deps"

--- a/tools/git-sync-deps
+++ b/tools/git-sync-deps
@@ -265,9 +265,6 @@ def main(argv):
     return 1
 
   git_sync_deps(deps_file_path, argv, shallow, verbose)
-  subprocess.check_call(
-      [sys.executable,
-       os.path.join(os.path.dirname(deps_file_path), 'bin', 'fetch-gn')])
   if not skip_emsdk:
     subprocess.check_call(
         [sys.executable,


### PR DESCRIPTION
Accommodates `gn` being a dependency via `esy-gn`.